### PR TITLE
add Skynet to demo tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 >This is a simple package made for encoding and decoding content hashes as specified in the [EIP 1577](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1577.md).
 This package will be useful for every [Ethereum](https://www.ethereum.org/) developer wanting to interact with [EIP 1577](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1577.md) compliant [ENS resolvers](http://docs.ens.domains/en/latest/introduction.html).
 
-Here you can find a [live demo](https://content-hash.surge.sh/) of this package.
+Here you can find a [live demo](https://5g0ab4bfifpa1rcvdainjdc9h6ldmmg4rlgke3rc1g1372mspdeevfg.siasky.net/) of this package.
 * link to [npm](https://www.npmjs.com/package/content-hash)
 * link to [Github](https://github.com/pldespaigne/content-hash)
 
@@ -15,6 +15,7 @@ Here you can find a [live demo](https://content-hash.surge.sh/) of this package.
 - `swarm-ns`
 - `ipfs-ns`
 - `ipns-ns`
+- `skynet-ns`
 - Every other codec supported by [multicodec](https://github.com/multiformats/multicodec) will be encoded by default in `utf-8`.
 > You can see the full list of codec supported [here](https://github.com/multiformats/multicodec/blob/master/table.csv)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,48 +1,74 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>Content Hash Calculator</title>
 
-		<!-- <script type="text/javascript" src="../dist/index.js"></script> -->
-		<script type="text/javascript" src="https://unpkg.com/content-hash/dist/index.js"></script>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Content Hash Calculator</title>
 
-		<script type="text/javascript" src="main.js"></script>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css">
-		<link rel="icon" href="gear.png" size="32x32">
-	</head>
-	<body>
-		<h1 class="title is-size-1 has-text-centered">Content Hash Calculator</h1>
-		<p class="has-text-centered">A simple tool to encode/decode content hashes for <a href="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1577.md" target="_blank">EIP 1577</a> compliant <a href="https://ens.readthedocs.io/en/latest/introduction.html" target="_blank">ENS Resolvers</a>.</p>
-		<p class="has-text-centered">You can find content-hash resolvers here :</p>
-		<p class="has-text-centered">MainNet <a href="https://etherscan.io/address/0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3" target="_blank">0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3</a></p>
-		<p class="has-text-centered">Ropsten <a href="https://ropsten.etherscan.io/address/0xde469c7106a9fbc3fb98912bb00be983a89bddca" target="_blank">0xde469c7106a9fbc3fb98912bb00be983a89bddca</a></p>
-		<p class="has-text-centered">Open the console to use the 'contentHash' object !</p>
-		<div class="section">
-			<h3 class="title">IPFS -> content hash</h3>
-			<input id="ipfs-input" class="level-item input" type="text" value="QmRcDsEJUdpg6EDaVeZGFJHU1WYCKHXaUXBCzHHuCZLNXw">
-			<button id="ipfs-encode" class="button is-primary">Encode</button>
-			<p id="ipfs-result"></p>
+	<!-- <script type="text/javascript" src="../dist/index.js"></script> -->
+	<!-- <script type="text/javascript" src="https://unpkg.com/content-hash/dist/index.js"></script> -->
+	<script type="text/javascript"
+		src="https://siasky.net/3ABmPw6vurLVi_8aYsGCajCoohQ7Z11-UTV1qtSJ35LdwQ/"></script>
+
+	<script type="text/javascript" src="main.js"></script>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css">
+	<link rel="icon" href="gear.png" size="32x32">
+</head>
+
+<body>
+	<h1 class="title is-size-1 has-text-centered">Content Hash Calculator</h1>
+	<p class="has-text-centered">A simple tool to encode/decode content hashes for <a
+			href="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1577.md" target="_blank">EIP
+			1577</a> compliant <a href="https://ens.readthedocs.io/en/latest/introduction.html"
+			target="_blank">ENS Resolvers</a>.</p>
+	<p class="has-text-centered">You can find content-hash resolvers here :</p>
+	<p class="has-text-centered">MainNet <a
+			href="https://etherscan.io/address/0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3"
+			target="_blank">0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3</a></p>
+	<p class="has-text-centered">Ropsten <a
+			href="https://ropsten.etherscan.io/address/0xde469c7106a9fbc3fb98912bb00be983a89bddca"
+			target="_blank">0xde469c7106a9fbc3fb98912bb00be983a89bddca</a></p>
+	<p class="has-text-centered">Open the console to use the 'contentHash' object !</p>
+	<div class="section">
+		<h3 class="title">IPFS -> content hash</h3>
+		<input id="ipfs-input" class="level-item input" type="text"
+			value="QmRcDsEJUdpg6EDaVeZGFJHU1WYCKHXaUXBCzHHuCZLNXw">
+		<button id="ipfs-encode" class="button is-primary">Encode</button>
+		<p id="ipfs-result"></p>
+	</div>
+	<div class="section">
+		<h3 class="title">Skynet Skylink -> content hash</h3>
+		<input id="skynet-input" class="input" type="text"
+			value="CABAB_1Dt0FJsxqsu_J4TodNCbCGvtFf1Uys_3EgzOlTcg">
+		<button id="skynet-encode" class="button is-primary">Encode</button>
+		<p id="skynet-result"></p>
+	</div>
+	<div class="section">
+		<h3 class="title">Swarm -> content hash</h3>
+		<input id="swarm-input" class="input" type="text"
+			value="d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162">
+		<button id="swarm-encode" class="button is-primary">Encode</button>
+		<p id="swarm-result"></p>
+	</div>
+	<div class="section">
+		<h3 class="title">Decode Content hash</h3>
+		<input id="content-input" class="input" type="text"
+			value="e40101701b20d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162">
+		<button id="content-decode" class="button is-primary">Decode</button>
+		<p id="codec-result"></p>
+		<a href="#" target="_blank" id="content-result"></a>
+	</div>
+	<footer class="footer">
+		<div class="content has-text-centered">
+			<p><strong>content-hash</strong> by <a href="https://twitter.com/pldespaigne"
+					target="_blank">@pldespaigne</a></p>
+			<p>Get the code on <a href="https://github.com/pldespaigne/content-hash"
+					target="_blank">Github</a> or download the <a
+					href="https://www.npmjs.com/package/content-hash" target="_blank">NPM
+					package</a> !</p>
 		</div>
-		<div class="section">
-			<h3 class="title">Swarm -> content hash</h3>
-			<input id="swarm-input" class="input" type="text" value="d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162">
-			<button id="swarm-encode" class="button is-primary">Encode</button>
-			<p id="swarm-result"></p>
-		</div>
-		<div class="section">
-			<h3 class="title">Decode Content hash</h3>
-			<input id="content-input" class="input" type="text" value="e40101701b20d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162">
-			<button id="content-decode" class="button is-primary">Decode</button>
-			<p id="codec-result"></p>
-			<a href="#" target="_blank" id="content-result"></a>
-		</div>
-		<footer class="footer">
-			<div class="content has-text-centered">
-				<p><strong>content-hash</strong> by <a href="https://twitter.com/pldespaigne" target="_blank">@pldespaigne</a></p>
-				<p>Get the code on <a href="https://github.com/pldespaigne/content-hash" target="_blank">Github</a> or download the <a href="https://www.npmjs.com/package/content-hash" target="_blank">NPM package</a> !</p>
-			</div>
-		</footer>
-	</body>
+	</footer>
+</body>
+
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -9,6 +9,13 @@ window.onload = () => {
 		ipfsResultElem.innerHTML = contentHash.fromIpfs(ipfsInputElem.value)
 	})
 
+	const skynetInputElem = document.getElementById('skynet-input')
+	const skynetButtonElem = document.getElementById('skynet-encode')
+	const skynetResultElem = document.getElementById('skynet-result')
+	skynetButtonElem.addEventListener('click', () => {
+		skynetResultElem.innerHTML = contentHash.encode("skynet-ns", skynetInputElem.value)
+	})
+
 	const swarmInputElem = document.getElementById('swarm-input')
 	const swarmButtonElem = document.getElementById('swarm-encode')
 	const swarmResultElem = document.getElementById('swarm-result')
@@ -27,10 +34,12 @@ window.onload = () => {
 		
 		if(contentHash.getCodec(contentInputElem.value) === 'ipfs-ns')codec = 'ipfs'
 		else if(contentHash.getCodec(contentInputElem.value) === 'swarm-ns')codec = 'swarm'
+		else if(contentHash.getCodec(contentInputElem.value) === 'skynet-ns')codec = 'skynet'
 
 		let url = 'https://'
 		if(codec === 'ipfs') url += 'gateway.ipfs.io/ipfs/' + cth + '/'
 		else if(codec === 'swarm') url += 'swarm-gateways.net/bzz:/' + cth + '/'
+		else if(codec === 'skynet') url += 'siasky.net/' + cth + '/'
 		else url = '#'
 
 		codecResultElem.innerHTML = 'codec : ' + codec

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/content-hash",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "resolver",
     "ipfs",
     "swarm",
+    "skynet",
     "content-hash",
     "content",
     "hash",


### PR DESCRIPTION
DXdao uses the `pldespaigne/content-hash` demo tool for generating content hashes and requested I add Skynet.

Required building the `ensdomains/content-hash` fork of the library. The site and library are both hosted on Skynet.

There is little to no error checking for skylinks in the tool, but I tried to follow the code that was already present.

Deployed Tool: https://5g0ab4bfifpa1rcvdainjdc9h6ldmmg4rlgke3rc1g1372mspdeevfg.siasky.net/
Hosted JS Lib: https://siasky.net/3ABmPw6vurLVi_8aYsGCajCoohQ7Z11-UTV1qtSJ35LdwQ/