### PR TITLE
Add Walrus Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - `onion3`
 - `skynet`
 - `arweave`
+- `walrus`
 
 ## 📥 Install
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -6,6 +6,7 @@ export const codeToName = {
   0x01bd: "onion3",
   0xb19910: "skynet",
   0xb29910: "arweave",
+  0xb59910: "walrus",
 } as const;
 
 export const nameToCode = {
@@ -16,6 +17,7 @@ export const nameToCode = {
   onion3: 0x01bd,
   skynet: 0xb19910,
   arweave: 0xb29910,
+  walrus: 0xb59910,
 } as const;
 
 export type CodecId = keyof typeof codeToName;

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -115,7 +115,7 @@ const encodes = {
     return base64Decode(value);
   },
   walrus: (value: string): Bytes => {
-    return base64Decode(value);
+    return hexStringToBytes(value);
   }
 };
 
@@ -153,6 +153,9 @@ const decodes = {
   base64: (value: Bytes): string => {
     return base64url.encode(value).substring(1);
   },
+  hex: (value: Bytes): string => {
+    return bytesToHexString(value);
+  },
 };
 
 export type Profile = {
@@ -188,7 +191,7 @@ export const profiles = {
   },
   walrus: {
     encode: encodes.walrus,
-    decode: decodes.base64,
+    decode: decodes.hex,
   },
   default: {
     encode: encodes.utf8,

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -114,6 +114,9 @@ const encodes = {
   arweave: (value: string): Bytes => {
     return base64Decode(value);
   },
+  walrus: (value: string): Bytes => {
+    return base64Decode(value);
+  }
 };
 
 /**
@@ -181,6 +184,10 @@ export const profiles = {
   },
   arweave: {
     encode: encodes.arweave,
+    decode: decodes.base64,
+  },
+  walrus: {
+    encode: encodes.walrus,
     decode: decodes.base64,
   },
   default: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
     "importHelpers": true, // This is only used for build validation. Since we do not have `tslib` installed, this will fail if we accidentally make use of anything that'd require injection of helpers.
 
     // Language and environment
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Node",
     "module": "ESNext",
     "target": "ES2021", // Setting this to `ES2021` enables native support for `Node v16+`: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping.
 


### PR DESCRIPTION
This PR adds support for the Walrus content hash in the content-hash library:

Updated codeToName and nameToCode mappings to include Walrus.

Added encoding/decoding logic for Walrus using hex format.

Updated profiles to handle Walrus content hash.

Updated README to list Walrus as a supported content hash type.