### PR TITLE
feat: add adnl codec for TON ADNL addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - `onion3`
 - `skynet`
 - `arweave`
+- `adnl`
 
 ## 📥 Install
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,10 @@ const skylink_contentHash =
 const arweave = "ys32Pt8uC7TrVxHdOLByOspfPEq2LO63wREHQIM9SJQ";
 const arweave_contentHash =
   "90b2ca05cacdf63edf2e0bb4eb5711dd38b0723aca5f3c4ab62ceeb7c1110740833d4894";
+const adnl =
+  "61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5";
+const adnl_contentHash =
+  "90b2da0561bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5";
 describe("content-hash (legacy tests)", () => {
   describe("decode", () => {
     test("ipfs", () => {
@@ -109,6 +113,9 @@ describe("content-hash", () => {
     test("arweave", () => {
       expect(decode(arweave_contentHash)).toEqual(arweave);
     });
+    test("adnl", () => {
+      expect(decode(adnl_contentHash)).toEqual(adnl);
+    });
   });
   describe("encode", () => {
     test("swarm", () => {
@@ -156,6 +163,14 @@ describe("content-hash", () => {
     test("arweave", () => {
       expect(encode("arweave", arweave)).toEqual(arweave_contentHash);
     });
+    test("adnl", () => {
+      expect(encode("adnl", adnl)).toEqual(adnl_contentHash);
+    });
+    test("adnl - error on wrong length", () => {
+      expect(() => encode("adnl", "deadbeef")).throws(
+        "ADNL address must be 32 bytes, got 4"
+      );
+    });
   });
   describe("getCodec", () => {
     test("swarm", () => {
@@ -178,6 +193,9 @@ describe("content-hash", () => {
     });
     test("arweave", () => {
       expect(getCodec(arweave_contentHash)).toEqual("arweave");
+    });
+    test("adnl", () => {
+      expect(getCodec(adnl_contentHash)).toEqual("adnl");
     });
   });
 });

--- a/src/map.ts
+++ b/src/map.ts
@@ -6,6 +6,7 @@ export const codeToName = {
   0x01bd: "onion3",
   0xb19910: "skynet",
   0xb29910: "arweave",
+  0xb69910: "adnl",
 } as const;
 
 export const nameToCode = {
@@ -16,6 +17,7 @@ export const nameToCode = {
   onion3: 0x01bd,
   skynet: 0xb19910,
   arweave: 0xb29910,
+  adnl: 0xb69910,
 } as const;
 
 export type CodecId = keyof typeof codeToName;

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -114,6 +114,13 @@ const encodes = {
   arweave: (value: string): Bytes => {
     return base64Decode(value);
   },
+  adnl: (value: string): Bytes => {
+    const bytes = hexStringToBytes(value);
+    if (bytes.length !== 32) {
+      throw new Error(`ADNL address must be 32 bytes, got ${bytes.length}`);
+    }
+    return bytes;
+  },
 };
 
 /**
@@ -182,6 +189,15 @@ export const profiles = {
   arweave: {
     encode: encodes.arweave,
     decode: decodes.base64,
+  },
+  adnl: {
+    encode: encodes.adnl,
+    decode: (value: Bytes): string => {
+      if (value.length !== 32) {
+        throw new Error(`ADNL address must be 32 bytes, got ${value.length}`);
+      }
+      return bytesToHexString(value);
+    },
   },
   default: {
     encode: encodes.utf8,


### PR DESCRIPTION
Adds the `adnl` codec (multicodec `0xb69910`) to `@ensdomains/content-hash`,
enabling ENSIP-7 contenthashes to point at TON ADNL endpoints.

An ADNL address is a 32-byte identifier derived from an Ed25519 public key:
`SHA-256( LE32(0x4813b4c6) || ed25519_public_key )`. Reference:
`ton-blockchain/ton`, `crypto/block/check-proof.cpp`.

Changes:

- `src/map.ts`: register `0xb69910` / `"adnl"` in both direction maps
- `src/profiles.ts`: add `encodes.adnl` and `profiles.adnl` with a strict
  32-byte length guard (inline decode, no shared helper)
- `src/index.test.ts`: 3 round-trip tests (decode, encode, getCodec) and
  1 error test for wrong length, using the live on-chain contenthash of
  `tonnet.eth`
- `README.md`: append `adnl` to the supported-codecs list

Format: raw 32-byte hex, lowercase, no `0x` prefix on decode output.

Codec registered in `multiformats/multicodec#402`
(`adnl, namespace, 0xb69910, draft`). This PR has no programmatic
dependency on that registry.
