### PR TITLE
fix: broken require() by dropping dead CJS build (ESM-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,12 @@
   "version": "3.1.0",
   "description": "A simple tool to encode/decode content hash for EIP 1577 compliant ENS Resolvers (fork of pldespaigne/content-hash)",
   "type": "module",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typings": "./dist/types/index.d.ts",
   "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/cjs/index.js"
+      "default": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -24,10 +20,9 @@
   "scripts": {
     "test": "vitest",
     "clean": "rm -rf ./dist",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "tsc --project tsconfig.build.json --module es2022 --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
-    "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
+    "build": "pnpm run clean && pnpm run build:esm && pnpm run build:types",
     "prepublish": "pnpm run build"
   },
   "keywords": [


### PR DESCRIPTION
Ship the package as ESM-only and remove the separate CommonJS build.

## Why

The CJS build was already non-functional: `multiformats` and `@multiformats/sha3` only expose the `import` export condition, so `require("multiformats/cid")` from our compiled `dist/cjs` output fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `require` resolution matches `[node, require, default]` and never `import`, so the dependency was unreachable from a CJS graph regardless of Node version. The shipped CJS output was dead on arrival — nothing actually consumed it.

## Consumer impact

- **ESM (`import` / `import()`)**: works on the entire supported range (`engines: node >=18`), which fully supports pure ESM. This is the only consumption path that ever worked.
- **`require()` on Node >= 20.19 / >= 22.12**: also works, via `require(esm)`, since the package and its dep graph are synchronous ESM and the export uses the `default` condition (matched by both `import` and `require(esm)`). Verified on Node 24.

## TypeScript consumers

- **`module: nodenext` / `bundler`** (the correct modern settings): everything type-checks, including a CommonJS consumer. Both `import ch = require("@ensdomains/content-hash")` and a static `import` in a `.cts` file are allowed — TypeScript models `require(esm)` and compiles them to a working `require()` call. Verified with TypeScript 6.
- **Legacy `module: commonjs` + `moduleResolution: node10`**: not supported. That resolver predates `exports` and cannot consume ESM-only packages (including our `multiformats`/`@multiformats/sha3` deps); it is also deprecated in TS 6 and removed in TS 7. Use `nodenext` or `bundler`.

Since the CJS build never worked, removing it is not a practical breaking change and does not require a major bump.

## Changes

- Drop the `build:cjs` script and `dist/cjs` output
- Remove `main` / `module` / `typings`; keep only the `exports` map
- Export conditions: `types` first, `default` last (per the Node.js and TypeScript packaging specs)
- `"type": "module"` makes the emitted `.d.ts` ESM, matching the `.js`; `package.json` stays explicitly exported